### PR TITLE
Rename --output CLI argument to --out

### DIFF
--- a/printstruct/main.py
+++ b/printstruct/main.py
@@ -32,14 +32,14 @@ def main() -> None:
     # If --no-limit is set, disable max_items
     max_items = None if args.no_limit else args.max_items
 
-    if args.output is not None:     # TODO: relocate this code for file output
+    if args.out is not None:     # TODO: relocate this code for file output
         # Determine filename
-        filename = args.output
+        filename = args.out
         # Add .txt extension only if no extension provided
         if not Path(filename).suffix:
             filename += '.txt'
 
-    if args.copy or args.output is not None:
+    if args.copy or args.out is not None:
         # Capture stdout
         output_buffer = io.StringIO()
         original_stdout = sys.stdout
@@ -66,7 +66,7 @@ def main() -> None:
             gitignore_depth=args.gitignore_depth,
             max_items=max_items,
         )
-        if args.output is not None:     # that file output code again
+        if args.out is not None:     # that file output code again
             # Write to file
             content = output_buffer.getvalue()
 

--- a/printstruct/services/parser.py
+++ b/printstruct/services/parser.py
@@ -13,7 +13,7 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("--max-items", type=max_items_int, default=20, help="Limit items shown per directory (default: 20). Use --no-limit for unlimited.")
     ap.add_argument("--version", "-v", action="store_true", help="Display the version of the tool")
     ap.add_argument("--zip", default=None, help="Create a zip file containing files under path (respects .gitignore)")
-    ap.add_argument("--output", "-o", default=None, help="Save tree structure to file")
+    ap.add_argument("--out", "-o", default=None, help="Save tree structure to file")
     ap.add_argument("--copy", "-c", action="store_true", help="Copy tree output to clipboard")
     ap.add_argument("--no-limit", action="store_true", help="Show all items regardless of count")
     return ap.parse_args()


### PR DESCRIPTION
Renamed the --output CLI argument to --out as requested.
Updated internal references accordingly.
