### PR TITLE
Fix broken version functionality for gitree

### DIFF
--- a/gitree/utilities/utils.py
+++ b/gitree/utilities/utils.py
@@ -58,4 +58,4 @@ def matches_extra(p: Path, root: Path, patterns: List[str], ignore_depth: Option
 
 def get_project_version() -> str:
     """Returns the current version of the project"""
-    return "0.1.0"
+    return "0.1.2"


### PR DESCRIPTION
Fixed the broken version functionality by hardcoding the version into the version returning function.

Output after the change:
<img width="566" height="119" alt="image" src="https://github.com/user-attachments/assets/04bbaa88-319c-42e7-b5f4-0c9887b820ea" />
