### PR TITLE
docs: group CLI arguments into basic, I/O, and listing sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,38 +196,44 @@ Gitree uses Continuous Integration (CI) to ensure code quality and prevent regre
 
 In addition to the directory path, the following options are available:
 
-| Argument            | Description |
-|---------------------|-------------|
-| `--version`, `-v`   | Displays the installed version. |
-| `--max-depth`           | Limits recursion depth. Example: `--depth 1` shows only top-level files and folders. |
-| `--hidden-items`    | Includes hidden files and directories. Does not override `.gitignore`. |
-| `--exclude`         | Patterns of files to exclude. Example: `--exclude *.pyc __pycache__`. |
-| `--exclude-depth`   | Limits depth for `--exclude` patterns. Example: `--exclude-depth 2` applies exclude rules only to first 2 levels. |
-| `--gitignore-depth` | Controls how deeply `.gitignore` files are discovered. Example: `--gitignore-depth 0` uses only the root `.gitignore`. |
-| `--no-gitignore`    | Ignores all `.gitignore` rules when set. |
-| `--max-items`       | Limits items shown per directory. Extra items are summarized as `... and x more items`. Default: `20`. |
-| `--no-limit`        | Removes the per-directory item limit. |
-| `--no-files`        | Hide files from the tree (only show directories). |
-| `--emoji`, `-e`     | Show emojis in tree output. |
-| `--summary`         | Print a summary of the number of files and folders at each level. |
-| `--zip [name]`, `-z` | Zips the project while respecting `.gitignore`. Example: `--zip a` creates `a.zip`. |
-| `--json [file]`     | Export tree as JSON to specified file. Example: `--json tree.json`. |
-| `--txt [file]`      | Export tree as text to specified file. Example: `--txt tree.txt`. |
-| `--md [file]`       | Export tree as Markdown to specified file. Example: `--md tree.md`. |
-| `--output [file]`, `-o` | Save tree structure to file. Example: `--output tree.txt` or `--output tree.md` for markdown format. |
-| `--copy`, `-c`      | Copy tree output to clipboard. |
-| `--include`         | Patterns of files to include (used in interactive mode). Example: `--include *.py *.js`. |
-| `--include-file-type` | Include files of a specific type. Example: `--include-file-type json` or `--include-file-type .py`. Case-insensitive. |
-| `--include-file-types` | Include files of multiple types. Example: `--include-file-types png jpg json`. Case-insensitive. |
-| `--json [file]`     | Export tree as JSON to specified file. **By default, includes file contents** (up to 1MB per file). |
-| `--txt [file]`      | Export tree as text to specified file. **By default, includes file contents** (up to 1MB per file). |
-| `--md [file]`       | Export tree as Markdown to specified file. **By default, includes file contents** with syntax highlighting (up to 1MB per file). |
-| `--no-contents`     | Don't include file contents when exporting to JSON, TXT, or MD formats. Only the tree structure will be included. |
-| `--interactive`, `-i` | Interactive mode: select files to include using a terminal-based UI. |
-| `--include`         | Patterns of files to include. Example: `--include *.py *.js`. |
-| `--init-config`     | Create a default `config.json` file in the current directory. |
-| `--config-user`     | Open `config.json` in the default editor. |
-| `--no-config`       | Ignore `config.json` and use hardcoded defaults. |
+### Basic CLI flags
+| Argument | Description |
+|----------|-------------|
+| `--version`, `-v` | Displays the installed version. |
+| `--interactive`, `-i` | Interactive selection UI. |
+| `--init-config` | Create a default `config.json` in the current directory. |
+| `--config-user` | Open `config.json` in the default editor. |
+| `--no-config` | Ignore `config.json` and use hardcoded defaults. |
+
+### Input/Output flags
+| Argument | Description |
+|----------|-------------|
+| `--zip [name]`, `-z` | Zip the project (respects `.gitignore`). Example: `--zip a` → `a.zip`. |
+| `--json [file]` | Export tree as JSON (includes file contents by default, up to 1MB/file). |
+| `--txt [file]` | Export tree as text (includes file contents by default, up to 1MB/file). |
+| `--md [file]` | Export tree as Markdown (includes contents with syntax highlighting). |
+| `--output [file]`, `-o` | Save tree structure to file (text or markdown). |
+| `--copy`, `-c` | Copy output to clipboard. |
+| `--no-contents` | Export only the tree structure (no file contents). |
+
+### Listing flags
+| Argument | Description |
+|----------|-------------|
+| `--max-depth` | Limit recursion depth (e.g., `--max-depth 1`). |
+| `--hidden-items` | Include hidden files and directories (does not override `.gitignore`). |
+| `--exclude [pattern]` | Exclude patterns (e.g., `--exclude *.pyc __pycache__`). |
+| `--exclude-depth [n]` | Limit depth for exclude patterns (e.g., `--exclude-depth 2`). |
+| `--gitignore-depth [n]` | Control discovery depth for `.gitignore` (e.g., `--gitignore-depth 0`). |
+| `--no-gitignore` | Ignore all `.gitignore` rules. |
+| `--max-items` | Limit items per directory (default: 20). |
+| `--no-limit` | Remove per-directory item limit. |
+| `--no-files` | Show only directories (hide files). |
+| `--emoji`, `-e` | Use emojis in output. |
+| `--summary` | Print file/folder counts per level. |
+| `--include [pattern]` | Include patterns (often used with interactive mode). |
+| `--include-file-type` | Include a specific file type (e.g., `.py`, `json`). |
+| `--include-file-types` | Include multiple file types (e.g., `png jpg json`). |
+
 
 
 ## 📝 File Contents in Exports


### PR DESCRIPTION
**Related to #122**
Additionally, at the time of submission of this PR:

- The referred issue is not blocked currently
- All unittests passed after changes were made

This PR reorganizes the CLI arguments section in the README by grouping flags into:
- Basic CLI flags
- Input/Output flags
- Listing flags

All existing CLI flags are preserved; this change only reorganizes
documentation and removes duplication for better readability.