### PR TITLE
Fix: prevent early exit to enable verbose logging with basic args (Closes #135)

### DIFF
--- a/gitree/main.py
+++ b/gitree/main.py
@@ -46,7 +46,7 @@ def main() -> None:
 
     # if some specific Basic CLI args given, execute and return
     # Handles for --version, --init-config, --config-user, --no-config
-    if handle_basic_cli_args(args): return
+    if handle_basic_cli_args(args): condition_for_no_output = True
 
 
     # Validate and resolve all paths


### PR DESCRIPTION
**Fixes #135**


This PR addresses an issue where the application would exit immediately when handling basic CLI arguments (such as `--version` or `--init-config`), causing the `--verbose` flag to be ignored.

**Changes:**
- Modified [gitree/main.py](cci:7://file:///Users/leo/Web/PR-project/gitree/gitree/main.py:0:0-0:0) to prevent early return in [main()](cci:1://file:///Users/leo/Web/PR-project/gitree/gitree/main.py:15:0-73:22) when [handle_basic_cli_args](cci:1://file:///Users/leo/Web/PR-project/gitree/gitree/services/basic_args_handling_service.py:48:0-67:16) handles an argument.
- Instead of returning, it now sets `condition_for_no_output` to `True`.
- This change ensures that the program execution continues to the end of the [main()](cci:1://file:///Users/leo/Web/PR-project/gitree/gitree/main.py:15:0-73:22) function where logs are flushed, allowing `--verbose` to work correctly while still suppressing the tree output for these commands.

**Closes:** #135

**Verification:**
I have verified the fix with the following commands.
1. Check version without verbose (Should show version only):
```
python3 -m gitree.main --version
# Output: 0.0.0 (dev)
```

2. Check version with verbose (Should show version AND logs):
```
python3 -m gitree.main --version --verbose
# Output:
# 0.0.0 (dev)
#
# LOG:
# [INFO] ...
```

3. Check normal execution (Should show tree):
```
python3 -m gitree.main
# Output: Directory tree structure...
```