### PR TITLE
Fix: ensure UTF-8 encoding for CLI output in tests

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -32,6 +32,7 @@ class TestBasic(unittest.TestCase):
             cwd=cwd or self.root,
             capture_output=True,
             text=True,
+            encoding="utf-8",
         )
 
 

--- a/tests/test_io_flags.py
+++ b/tests/test_io_flags.py
@@ -34,6 +34,7 @@ class TestIOFlags(unittest.TestCase):
             cwd=self.root,
             capture_output=True,
             text=True,
+            encoding="utf-8",
         )
 
 


### PR DESCRIPTION
**Fixes #133**

**Fixes issue #133 **

Additionally, at the time of submission of this PR:

- The referred issue is not blocked currently
- All unittests passed after changes were made
