### PR TITLE
Update default '--max-lines' from 30 to 40

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ In addition to the directory path, the following options are available:
 | `--gitignore-depth [n]` | Control discovery depth for `.gitignore` (e.g., `--gitignore-depth 0`). |
 | `--no-gitignore` | Ignore all `.gitignore` rules. |
 | `--max-items` | Limit items per directory (default: 20). |
-| `--max-lines` | Limit lines (default: 30). |
+| `--max-lines` | Limit lines (default: 40). |
 | `--no-limit` | Remove per-directory item limit. |
 | `--no-max-lines` | Disable total lines limit. |
 | `--no-files` | Show only directories (hide files). |

--- a/gitree/utilities/config.py
+++ b/gitree/utilities/config.py
@@ -22,7 +22,7 @@ def get_default_config() -> Dict[str, Any]:
     """
     return {
         "max_items": 20,
-        "max_lines": 30,
+        "max_lines": 40,
         "max_depth": None,
         "gitignore_depth": None,
         "exclude_depth": None,


### PR DESCRIPTION
**Fixes #171**

**Fixes issue #171**

We update the `config.py` and `README.md` to incorporate the change.

Additionally, at the time of submission of this PR:

- The referred issue is not blocked currently
- All unittests passed after changes were made
<img width="650" height="161" alt="image" src="https://github.com/user-attachments/assets/db9cb983-75a6-49a1-8998-ec5423c52750" />