### PR TITLE
Bump Python version requirement to 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "gitree"
 version = "0.0.0"
 description = "gitree: git-aware project tree printing and zipping for docs and LLMs"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "MIT" }
 authors = [{ name = "Shahzaib Ahmad" }]
 dependencies = ["pathspec>=0.11", "pyperclip>=1.5", "prompt_toolkit>=3.0", "colorama>=0.4.6"]


### PR DESCRIPTION
Fixes python version mismatch issues for the next pypi release

Additionally, at the time of submission of this PR:

- The referred issue is not blocked currently
- All unittests passed after changes were made
