### PR TITLE
Fix: #195 Split test_listing_flags.py into two independent files

### DIFF
--- a/tests/test_listing_control_flags.py
+++ b/tests/test_listing_control_flags.py
@@ -1,0 +1,53 @@
+from tests.base_setup import BaseCLISetup
+
+
+class TestListingControlFlags(BaseCLISetup):
+    """
+    Test class for listing control flags (--no-* flags).
+    These flags control what gets displayed in the tree output.
+    """
+
+    def test_entry_point_no_files(self):
+        result = self._run_cli("--no-files")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertTrue(result.stdout.strip())
+        self.assertIn("folder", result.stdout)
+        self.assertNotIn("file.txt", result.stdout)
+        self.assertNotIn("nested.txt", result.stdout)
+
+
+    def test_entry_point_no_limit(self):
+        # Override base structure for this test
+        (self.root / "file.txt").unlink()
+
+        for i in range(30):  # default limit is 20
+            (self.root / "folder" / f"file{i}.txt").write_text("data")
+
+        result = self._run_cli("--no-limit", "--no-max-lines")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertTrue(result.stdout.strip())
+
+        for i in range(30):
+            self.assertIn(f"file{i}.txt", result.stdout)
+
+
+    def test_entry_point_no_color(self):
+        # Create additional structure
+        (self.root / ".hidden_file").write_text("hidden")
+
+        # Test with color (default) - should contain ANSI color codes
+        result_with_color = self._run_cli("--hidden-items")
+
+        self.assertEqual(result_with_color.returncode, 0, msg=result_with_color.stderr)
+        self.assertTrue(result_with_color.stdout.strip())
+        # Check that ANSI escape sequences are present (color codes start with \x1b[)
+        self.assertIn("\x1b[", result_with_color.stdout, msg="Expected ANSI color codes in output")
+
+        # Test with --no-color flag - should NOT contain ANSI color codes
+        result_no_color = self._run_cli("--hidden-items", "--no-color")
+
+        self.assertEqual(result_no_color.returncode, 0, msg=result_no_color.stderr)
+        self.assertTrue(result_no_color.stdout.strip())
+        self.assertNotIn("\x1b[", result_no_color.stdout, msg="Expected no ANSI color codes with --no-color flag")

--- a/tests/test_listing_flags.py
+++ b/tests/test_listing_flags.py
@@ -22,16 +22,6 @@ class TestListingFlags(BaseCLISetup):
         self.assertIn(self.__build_name_with_emoji('folder', NORMAL_DIR_EMOJI), result.stdout)
 
 
-    def test_entry_point_no_files(self):
-        result = self._run_cli("--no-files")
-
-        self.assertEqual(result.returncode, 0, msg=result.stderr)
-        self.assertTrue(result.stdout.strip())
-        self.assertIn("folder", result.stdout)
-        self.assertNotIn("file.txt", result.stdout)
-        self.assertNotIn("nested.txt", result.stdout)
-
-
     def test_entry_point_max_depth(self):
         result = self._run_cli("--max-depth", "1")
 
@@ -40,22 +30,6 @@ class TestListingFlags(BaseCLISetup):
         self.assertIn("file.txt", result.stdout)
         self.assertIn("folder", result.stdout)
         self.assertNotIn("nested.txt", result.stdout)
-
-
-    def test_entry_point_no_limit(self):
-        # Override base structure for this test
-        (self.root / "file.txt").unlink()
-
-        for i in range(30):  # default limit is 20
-            (self.root / "folder" / f"file{i}.txt").write_text("data")
-
-        result = self._run_cli("--no-limit", "--no-max-lines")
-
-        self.assertEqual(result.returncode, 0, msg=result.stderr)
-        self.assertTrue(result.stdout.strip())
-
-        for i in range(30):
-            self.assertIn(f"file{i}.txt", result.stdout)
 
 
     def test_entry_point_hidden_items(self):
@@ -130,26 +104,6 @@ class TestListingFlags(BaseCLISetup):
         (self.root / "script.py").write_text("python")
         (self.root / "error.log").write_text("log")
         (self.root / "data.json").write_text("{}")
-        
-
-    def test_entry_point_no_color(self):
-        # Create additional structure
-        (self.root / ".hidden_file").write_text("hidden")
-
-        # Test with color (default) - should contain ANSI color codes
-        result_with_color = self._run_cli("--hidden-items")
-
-        self.assertEqual(result_with_color.returncode, 0, msg=result_with_color.stderr)
-        self.assertTrue(result_with_color.stdout.strip())
-        # Check that ANSI escape sequences are present (color codes start with \x1b[)
-        self.assertIn("\x1b[", result_with_color.stdout, msg="Expected ANSI color codes in output")
-
-        # Test with --no-color flag - should NOT contain ANSI color codes
-        result_no_color = self._run_cli("--hidden-items", "--no-color")
-
-        self.assertEqual(result_no_color.returncode, 0, msg=result_no_color.stderr)
-        self.assertTrue(result_no_color.stdout.strip())
-        self.assertNotIn("\x1b[", result_no_color.stdout, msg="Expected no ANSI color codes with --no-color flag")
 
 
     def test_entry_point_include(self):


### PR DESCRIPTION
Fixes #I195

Changes Made:

1. Created new file test_listing_control_flags.py containing 3 tests for --no-* flags:

- test_entry_point_no_files - tests --no-files flag
- test_entry_point_no_limit - tests --no-limit and --no-max-lines flags
- test_entry_point_no_color - tests --no-color flag

2. Updated test_listing_flags.py by removing the 3 moved test methods


Test Results:

- All 16 tests pass (3 in the new file + 13 remaining in the original file)
- The new TestListingControlFlags class inherits from BaseCLISetup just like the original class