### PR TITLE
Update pr workflow to not use admin ref

### DIFF
--- a/.github/workflows/pr_review_notice.yml
+++ b/.github/workflows/pr_review_notice.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  # keep these, but we’ll actually use PAT for the comment
   issues: write
   pull-requests: write
 
@@ -16,8 +15,8 @@ jobs:
     steps:
       - uses: actions/github-script@v7
         with:
-          # PAT makes it work for fork PRs when GITHUB_TOKEN is blocked
-          github-token: ${{ secrets.PR_COMMENT_TOKEN }}
+          # Use the built-in token so the comment is authored by github-actions[bot]
+          github-token: ${{ github.token }}
           script: |
             const { owner, repo } = context.repo;
 
@@ -34,7 +33,10 @@ jobs:
 
             // Avoid duplicate comment spam
             const { data: comments } = await github.rest.issues.listComments({
-              owner, repo, issue_number: pr_number, per_page: 100,
+              owner,
+              repo,
+              issue_number: pr_number,
+              per_page: 100,
             });
 
             const already = comments.some(c => (c.body || "").includes("Thank you for the pull request! ✅"));


### PR DESCRIPTION
Fixes pr workflow issue

Additionally, at the time of submission of this PR:

- The referred issue is not blocked currently
- All unittests passed after changes were made
