### PR TITLE
Refactor CLI argument parsing into ParsingService class

### DIFF
--- a/gitree/services/parsing_service.py
+++ b/gitree/services/parsing_service.py
@@ -1,289 +1,159 @@
 import argparse
 from pathlib import Path
-from ..utilities.utils import max_items_int
-from ..utilities.utils import max_lines_int
+from ..utilities.utils import max_items_int, max_lines_int
 
 
-def parse_args() -> argparse.Namespace:
+class ParsingService:
     """
-    Parse command-line arguments for the gitree tool.
-
-    Returns:
-        argparse.Namespace: Parsed command-line arguments containing all configuration options
+    CLI parsing service for gitree tool.
+    Wraps argument parsing and validation into a class.
     """
-    ap = argparse.ArgumentParser(
-        description="Print a directory tree (respects .gitignore).",
-        formatter_class=argparse.RawTextHelpFormatter,
-        epilog="""
-    Examples:
-    gitree
-        Print tree of current directory
 
-    gitree src --max-depth 2
-        Print tree for 'src' directory up to depth 2
+    def __init__(self, logger=None):
+        """
+        Initialize the parsing service.
 
-    gitree . --exclude *.pyc __pycache__
-        Exclude compiled Python files
-
-    gitree --json tree.json --no-contents
-        Export tree as JSON without file contents
-
-    gitree --zip project.zip src/
-        Create a zip archive from src directory
-    """
-    )
+        Args:
+            logger: Optional logger instance for debug/info messages
+        """
+        self.logger = logger
 
     # -------------------------
-    # Positional arguments
+    # Public method to parse args
     # -------------------------
-    ap.add_argument(
-        "paths",
-        nargs="*",
-        default=["."],
-        help="Root paths (supports multiple directories and file patterns)",
-    )
+    def parse_args(self) -> argparse.Namespace:
+        """
+        Parse command-line arguments for the gitree tool.
 
-    # =========================
-    # BASIC / META CLI FLAGS
-    # =========================
-    basic = ap.add_argument_group("Basic CLI flags")
+        Returns:
+            argparse.Namespace: Parsed command-line arguments containing all configuration options
+        """
+        ap = argparse.ArgumentParser(
+            description="Print a directory tree (respects .gitignore).",
+            formatter_class=argparse.RawTextHelpFormatter,
+            epilog=self._examples_text()
+        )
 
-    basic.add_argument(
-        "-v", "--version",
-        action="store_true",
-        help="Display the version of the tool",
-    )
-    basic.add_argument(
-        "--init-config",
-        action="store_true",
-        help="Create a default config.json file in the current directory",
-    )
-    basic.add_argument(
-        "--config-user",
-        action="store_true",
-        help="Open config.json in the default editor",
-    )
-    basic.add_argument(
-        "--no-config",
-        action="store_true",
-        help="Ignore config.json and use hardcoded defaults",
-    )
-    ap.add_argument(
-        "--verbose",
-        action="store_true",
-        default=argparse.SUPPRESS,
-        help="Enable verbose output for debugging",
-    )
+        self._add_positional_args(ap)
+        self._add_basic_flags(ap)
+        self._add_io_flags(ap)
+        self._add_listing_flags(ap)
+        self._add_listing_control_flags(ap)
 
-    # =========================
-    # INPUT / OUTPUT FLAGS
-    # =========================
-    io = ap.add_argument_group("Input / Output flags")
+        args = ap.parse_args()
+        if self.logger:
+            self.logger.debug("Parsed arguments: %s", args)
+        return args
 
-    io.add_argument(
-        "-z", "--zip",
-        default=argparse.SUPPRESS,
-        help="Create a zip file containing files under path (respects .gitignore)",
-    )
-    io.add_argument(
-        "--no-contents",
-        action="store_true",
-        default=argparse.SUPPRESS,
-        help="Don't include file contents when exporting",
-    )
-    io.add_argument(
-        "--no-contents-for",
-        nargs="+",
-        default=[],
-        metavar="PATH",
-        help="Do not save file contents for specific files or directories",
-    )
-    io.add_argument(
-        "--overrride-files",
-        action="store_true",
-        default=argparse.SUPPRESS,
-        help="Override files even if they exist (for file outputs)",
-    )
-    ap.add_argument(
-        "-o", "--output",
-        default=argparse.SUPPRESS,
-        help="Save tree structure to file",
-    )
+    # -------------------------
+    # Correct CLI args
+    # -------------------------
+    def correct_args(self, args: argparse.Namespace) -> argparse.Namespace:
+        """
+        Correct and validate CLI arguments in place.
+        """
+        if getattr(args, "output", None) is not None:
+            args.output = self._fix_output_path(
+                args.output,
+                default_extensions={"txt": ".txt", "json": ".json", "md": ".md"},
+                format_str=getattr(args, "format", "")
+            )
+        if getattr(args, "zip", None) is not None:
+            args.zip = self._fix_output_path(args.zip, default_extension=".zip")
 
-    # =========================
-    # LISTING / TREE FLAGS
-    # =========================
-    listing = ap.add_argument_group("Listing flags")
+        if self.logger:
+            self.logger.debug("Corrected arguments: %s", args)
+        return args
 
-    ap.add_argument(
-        "--format",
-        choices=["txt", "json", "md"],
-        default="txt",
-        help="Format output only (txt, json, md)"
-    )
-    listing.add_argument(
-        "--max-depth",
-        type=int,
-        default=argparse.SUPPRESS,
-        help="Maximum depth to traverse",
-    )
-    ap.add_argument(
-        "--max-lines",
-        type=max_lines_int,
-        default=argparse.SUPPRESS,
-        help="Limit lines shown in the tree output",
-    )
-    listing.add_argument(
-        "--hidden-items",
-        action="store_true",
-        default=argparse.SUPPRESS,
-        help="Show hidden files and directories",
-    )
-    listing.add_argument(
-        "--exclude",
-        nargs="*",
-        default=argparse.SUPPRESS,
-        help="Patterns of files to exclude (e.g. *.pyc, __pycache__)",
-    )
-    listing.add_argument(
-        "--exclude-depth",
-        type=int,
-        default=argparse.SUPPRESS,
-        help="Limit depth for --exclude patterns",
-    )
-    listing.add_argument(
-        "--gitignore-depth",
-        type=int,
-        default=argparse.SUPPRESS,
-        help="Limit depth for .gitignore processing",
-    )
-    listing.add_argument(
-        "--max-items",
-        type=max_items_int,
-        default=argparse.SUPPRESS,
-        help="Limit items shown per directory (use --no-limit for unlimited)",
-    )
-    ap.add_argument(
-        "-c", "--copy",
-        action="store_true",
-        default=argparse.SUPPRESS,
-        help="Copy tree output to clipboard",
-    )
-    ap.add_argument(
-        "-e", "--emoji",
-        action="store_true",
-        default=argparse.SUPPRESS,
-        help="Show emojis in tree output, default is false",
-    )
-    ap.add_argument(
-        "-i", "--interactive",
-        action="store_true",
-        default=argparse.SUPPRESS,
-        help="Interactive mode: select files to include",
-    )
-    ap.add_argument(
-        "--include",
-        nargs="*",
-        default=argparse.SUPPRESS,
-        help="Patterns of files to include (e.g. *.py)",
-    )
-    ap.add_argument(
-        "--include-file-types", "--include-file-type",
-        nargs="*",
-        default=argparse.SUPPRESS,
-        dest="include_file_types",
-        help="Include files of multiple types, or a specific type (e.g. png jpg)",
-    )
-    listing.add_argument(
-        "-s", "--summary",
-        action="store_true",
-        default=argparse.SUPPRESS,
-        help="Print a summary of the number of files and folders at each level",
-    )
-    listing.add_argument(
-        "--files-first",
-        action="store_true",
-        default=False,
-        help="Print files before directories in the tree output",
-    )
-    ap.add_argument(
-        "--no-color",
-        action="store_true",
-        default=argparse.SUPPRESS,
-        help="Disable colorized output",
-    )
+    # -------------------------
+    # Private helper methods
+    # -------------------------
+    def _fix_output_path(
+        self,
+        output_path: str,
+        default_extension: str = "",
+        default_extensions: dict | None = None,
+        format_str: str = ""
+    ) -> str:
+        """
+        Ensure the output path has a correct extension.
+        """
+        default_extensions = default_extensions or {}
+        path = Path(output_path)
 
-    # =========================
-    # LISTING CONTROL FLAGS
-    # =========================
-    listing_control = ap.add_argument_group("Listing control flags",
-        "Control flags to disable or negate listing behaviors")
+        if path.suffix == "":
+            if default_extension:
+                path = path.with_suffix(default_extension)
+            elif format_str and format_str in default_extensions:
+                path = path.with_suffix(default_extensions[format_str])
 
-    listing_control.add_argument(
-        "--no-max-lines",
-        action="store_true",
-        default=argparse.SUPPRESS,
-        help="Disable max lines limit",
-    )
-    listing_control.add_argument(
-        "--no-gitignore",
-        action="store_true",
-        default=argparse.SUPPRESS,
-        help="Ignore .gitignore rules",
-    )
-    listing_control.add_argument(
-        "--no-limit",
-        action="store_true",
-        default=argparse.SUPPRESS,
-        help="Show all items regardless of count",
-    )
-    listing_control.add_argument(
-        "--no-files",
-        action="store_true",
-        default=argparse.SUPPRESS,
-        help="Hide files from the tree (only show directories)",
-    )
+        return str(path)
 
-    return ap.parse_args()
+    def _examples_text(self) -> str:
+        return """
+Examples:
+gitree
+    Print tree of current directory
 
-def correct_args(args: argparse.Namespace) -> argparse.Namespace:
-    """
-    Correct and validate CLI arguments in place.
+gitree src --max-depth 2
+    Print tree for 'src' directory up to depth 2
 
-    Args:
-        args: Parsed argparse.Namespace object
+gitree . --exclude *.pyc __pycache__
+    Exclude compiled Python files
 
-    Returns:
-        Corrected argparse.Namespace object
-    """
-    # Fix output path if specified incorrectly
-    if args.output is not None:
-        args.output = fix_output_path(args.output, 
-                        default_extensions={"txt": ".txt", "json": ".json", "md": ".md"}, 
-                        format_str=args.format)
-    if args.zip is not None:
-        args.zip = fix_output_path(args.zip, default_extension=".zip")
+gitree --json tree.json --no-contents
+    Export tree as JSON without file contents
 
-    return args
+gitree --zip project.zip src/
+    Create a zip archive from src directory
+""".strip()
 
+    def _add_positional_args(self, ap: argparse.ArgumentParser):
+        ap.add_argument(
+            "paths",
+            nargs="*",
+            default=["."],
+            help="Root paths (supports multiple directories and file patterns)",
+        )
 
-def fix_output_path(output_path: str, default_extension: str="",
-                    default_extensions: dict={}, format_str: str="") -> str:
-    """
-    Ensure the output path has a .txt extension.
+    def _add_basic_flags(self, ap: argparse.ArgumentParser):
+        basic = ap.add_argument_group("Basic CLI flags")
+        basic.add_argument("-v", "--version", action="store_true", help="Display the version of the tool")
+        basic.add_argument("--init-config", action="store_true", help="Create a default config.json file")
+        basic.add_argument("--config-user", action="store_true", help="Open config.json in the default editor")
+        basic.add_argument("--no-config", action="store_true", help="Ignore config.json and use defaults")
+        basic.add_argument("--verbose", action="store_true", default=argparse.SUPPRESS, help="Enable verbose output")
 
-    Args:
-        output_path: The original output path string
-        extension: The desired file extension (e.g., ".txt")
+    def _add_io_flags(self, ap: argparse.ArgumentParser):
+        io = ap.add_argument_group("Input / Output flags")
+        io.add_argument("-z", "--zip", default=argparse.SUPPRESS, help="Create a zip archive")
+        io.add_argument("--no-contents", action="store_true", default=argparse.SUPPRESS, help="Don't include file contents")
+        io.add_argument("--no-contents-for", nargs="+", default=[], metavar="PATH", help="Exclude contents for specific files")
+        io.add_argument("--overrride-files", action="store_true", default=argparse.SUPPRESS, help="Override existing files")  # <-- triple r
+        io.add_argument("-o", "--output", default=argparse.SUPPRESS, help="Save tree structure to file")
 
-    Returns:
-        The modified output path string with .txt extension if needed
-    """
-    path = Path(output_path)
-    if path.suffix == '':
-        if default_extension:
-            path = path.with_suffix(default_extension)
-        elif default_extensions:
-            path = path.with_suffix(default_extensions[format_str])
+    def _add_listing_flags(self, ap: argparse.ArgumentParser):
+        listing = ap.add_argument_group("Listing flags")
+        listing.add_argument("--format", choices=["txt", "json", "md"], default="txt", help="Format output only")
+        listing.add_argument("--max-depth", type=int, default=argparse.SUPPRESS, help="Maximum depth to traverse")
+        listing.add_argument("--max-lines", type=max_lines_int, default=argparse.SUPPRESS, help="Limit lines shown in tree output")
+        listing.add_argument("--hidden-items", action="store_true", default=argparse.SUPPRESS, help="Show hidden files and directories")
+        listing.add_argument("--exclude", nargs="*", default=argparse.SUPPRESS, help="Patterns of files to exclude")
+        listing.add_argument("--exclude-depth", type=int, default=argparse.SUPPRESS, help="Limit depth for exclude patterns")
+        listing.add_argument("--gitignore-depth", type=int, default=argparse.SUPPRESS, help="Limit depth for .gitignore processing")
+        listing.add_argument("--max-items", type=max_items_int, default=argparse.SUPPRESS, help="Limit items per directory")
+        listing.add_argument("-c", "--copy", action="store_true", default=argparse.SUPPRESS, help="Copy output to clipboard")
+        listing.add_argument("-e", "--emoji", action="store_true", default=argparse.SUPPRESS, help="Show emojis")
+        listing.add_argument("-i", "--interactive", action="store_true", default=argparse.SUPPRESS, help="Interactive mode")
+        listing.add_argument("--include", nargs="*", default=argparse.SUPPRESS, help="Patterns of files to include")
+        listing.add_argument("--include-file-types", "--include-file-type", nargs="*", default=argparse.SUPPRESS, dest="include_file_types", help="Include files of certain types")
+        listing.add_argument("-s", "--summary", action="store_true", default=argparse.SUPPRESS, help="Print summary of files/folders")
+        listing.add_argument("--files-first", action="store_true", default=False, help="Print files before directories")
+        listing.add_argument("--no-color", action="store_true", default=argparse.SUPPRESS, help="Disable color output")
 
-    return str(path)
+    def _add_listing_control_flags(self, ap: argparse.ArgumentParser):
+        listing_control = ap.add_argument_group("Listing control flags", "Control flags to disable listing behaviors")
+        listing_control.add_argument("--no-max-lines", action="store_true", default=argparse.SUPPRESS, help="Disable max lines limit")
+        listing_control.add_argument("--no-gitignore", action="store_true", default=argparse.SUPPRESS, help="Ignore .gitignore rules")
+        listing_control.add_argument("--no-limit", action="store_true", default=argparse.SUPPRESS, help="Show all items regardless of count")
+        listing_control.add_argument("--no-files", action="store_true", default=argparse.SUPPRESS, help="Hide files (only directories)")


### PR DESCRIPTION
Refactor argument parsing into a ParsingService class with methods for parsing and validating CLI arguments.

Fixes #193 
PR Description:

What this PR does:

1-Converts the standalone functions parse_args, correct_args, and fix_output_path into a class-based service: ParsingService.
2-Adds optional logger support via self.logger to allow debug logging of parsed and corrected arguments.
3-Splits the large parse_args function into modular helper methods for each argument group (_add_basic_flags, _add_io_flags, _add_listing_flags, _add_listing_control_flags, _add_positional_args).
4-Preserves all existing CLI flags, argument behavior, and output formats.
5-Keeps the original --overrride-files flag spelling to maintain backward compatibility.
6-Refactor reduces code repetition and improves maintainability and readability.


