### PR TITLE
docs: add relative file path comments to all .py files

### DIFF
--- a/gitree/constants/__init__.py
+++ b/gitree/constants/__init__.py
@@ -1,0 +1,1 @@
+# gitree/constants/__init__.py

--- a/gitree/constants/constant.py
+++ b/gitree/constants/constant.py
@@ -1,3 +1,4 @@
+# gitree/constants/constant.py
 # tree structure characters
 BRANCH = "├─ "
 LAST   = "└─ "

--- a/gitree/objects/__init__.py
+++ b/gitree/objects/__init__.py
@@ -1,0 +1,1 @@
+# gitree/objects/__init__.py

--- a/gitree/objects/config.py
+++ b/gitree/objects/config.py
@@ -1,3 +1,4 @@
+# gitree/objects/config.py
 import argparse, json, os
 from typing import Any
 

--- a/gitree/services/__init__.py
+++ b/gitree/services/__init__.py
@@ -1,0 +1,1 @@
+# gitree/services/__init__.py

--- a/gitree/services/basic_args_handling_service.py
+++ b/gitree/services/basic_args_handling_service.py
@@ -1,3 +1,4 @@
+# gitree/services/basic_args_handling_service.py
 from ..utilities.config import create_default_config, open_config_in_editor
 from ..utilities.logger import Logger, OutputBuffer
 import argparse, glob, sys

--- a/gitree/services/interactive.py
+++ b/gitree/services/interactive.py
@@ -1,3 +1,4 @@
+# gitree/services/interactive.py
 """
 Interactive file selection UI for gitree.
 

--- a/gitree/services/list_enteries.py
+++ b/gitree/services/list_enteries.py
@@ -1,3 +1,4 @@
+# gitree/services/list_enteries.py
 from typing import List, Optional, Tuple
 from pathlib import Path
 from ..utilities.gitignore import GitIgnoreMatcher

--- a/gitree/services/parsing_service.py
+++ b/gitree/services/parsing_service.py
@@ -1,3 +1,4 @@
+# gitree/services/parsing_service.py
 import argparse
 from pathlib import Path
 from ..utilities.utils import max_items_int, max_lines_int

--- a/gitree/services/tree_formatting_service.py
+++ b/gitree/services/tree_formatting_service.py
@@ -1,3 +1,4 @@
+# gitree/services/tree_formatting_service.py
 import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set

--- a/gitree/services/tree_service.py
+++ b/gitree/services/tree_service.py
@@ -1,3 +1,4 @@
+# gitree/services/tree_service.py
 import sys
 from pathlib import Path
 from typing import List, Optional, Set

--- a/gitree/services/zipping_service.py
+++ b/gitree/services/zipping_service.py
@@ -1,3 +1,4 @@
+# gitree/services/zipping_service.py
 from pathlib import Path
 from typing import List, Optional, Set
 from ..utilities.gitignore import GitIgnoreMatcher

--- a/gitree/utilities/__init__.py
+++ b/gitree/utilities/__init__.py
@@ -1,0 +1,1 @@
+# gitree/utilities/__init__.py

--- a/gitree/utilities/colors.py
+++ b/gitree/utilities/colors.py
@@ -1,3 +1,4 @@
+# gitree/utilities/colors.py
 """
 Color utility for terminal output using colorama.
 

--- a/gitree/utilities/config.py
+++ b/gitree/utilities/config.py
@@ -1,3 +1,4 @@
+# gitree/utilities/config.py
 import json
 import sys
 import os

--- a/gitree/utilities/gitignore.py
+++ b/gitree/utilities/gitignore.py
@@ -1,3 +1,4 @@
+# gitree/utilities/gitignore.py
 from pathlib import Path
 from typing import Optional
 import pathspec

--- a/gitree/utilities/logger.py
+++ b/gitree/utilities/logger.py
@@ -1,3 +1,4 @@
+# gitree/utilities/logger.py
 import sys
 from typing import List, Literal, Dict
 

--- a/gitree/utilities/utils.py
+++ b/gitree/utilities/utils.py
@@ -1,3 +1,4 @@
+# gitree/utilities/utils.py
 import argparse
 import pathspec
 import random, os, pyperclip, sys

--- a/tests/base_setup.py
+++ b/tests/base_setup.py
@@ -1,3 +1,4 @@
+# tests/base_setup.py
 import unittest
 import tempfile
 import subprocess

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,4 @@
+# tests/test_basic.py
 from tests.base_setup import BaseCLISetup
 
 

--- a/tests/test_io_flags.py
+++ b/tests/test_io_flags.py
@@ -1,3 +1,4 @@
+# tests/test_io_flags.py
 import zipfile
 
 from tests.base_setup import BaseCLISetup

--- a/tests/test_listing_control_flags.py
+++ b/tests/test_listing_control_flags.py
@@ -1,3 +1,4 @@
+# tests/test_listing_control_flags.py
 from tests.base_setup import BaseCLISetup
 
 

--- a/tests/test_listing_flags.py
+++ b/tests/test_listing_flags.py
@@ -1,3 +1,4 @@
+# tests/test_listing_flags.py
 from gitree.constants.constant import FILE_EMOJI, EMPTY_DIR_EMOJI, NORMAL_DIR_EMOJI
 from tests.base_setup import BaseCLISetup
 


### PR DESCRIPTION
## Description
As requested, I have added a comment at the top of every `.py` file stating its relative path within the project. 

## Changes
- Added relative path comments to 23 `.py` files (including services, utilities, objects, and tests).
- Ensured `__init__.py` files are also included.

Closes #210 
