### PR TITLE
Add colored output to logger

### DIFF
--- a/gitree/utilities/logging_utility.py
+++ b/gitree/utilities/logging_utility.py
@@ -4,6 +4,8 @@
 Code file for housing Logger and OutputBuffer classes.
 """
 
+from ..utilities.color_utility import Color
+
 
 class Logger:
     """
@@ -112,7 +114,20 @@ class Logger:
             The message prefixed with the log level
         """
 
-        return f"[{self._LEVEL_NAMES[level]}] {message}"
+        label = self._LEVEL_NAMES[level]
+
+        if level == self.DEBUG:
+            colored_label = Color.blue(f"[{label}]")
+        elif level == self.INFO:
+            colored_label = Color.green(f"[{label}]")
+        elif level == self.WARNING:
+            colored_label = Color.yellow(f"[{label}]")
+        elif level == self.ERROR:
+            colored_label = Color.red(f"[{label}]")
+        else:
+            colored_label = f"[{label}]"
+
+        return f"{colored_label} {message}"
 
 
 class OutputBuffer(Logger):


### PR DESCRIPTION
Fixes #249
## Summary

This PR adds colored output to log level labels (`[DEBUG]`, `[INFO]`, `[WARNING]`, `[ERROR]`) using the existing `Color` utility to improve CLI readability while keeping the message text unchanged for clarity.

## Changes Made

- Added ANSI color formatting to log level prefixes in `Logger`
- Integrated existing `Color` utility for styling
- Preserved default message color for improved readability

### Files Modified

- `gitree/utilities/logging_utility.py`

## Example Output
<img width="747" height="85" alt="image" src="https://github.com/user-attachments/assets/f7d67a8a-73ef-48c8-89ff-57ec11b3b84e" />


Additionally, at the time of submission of this PR:

- The referred issue is not blocked currently
- All unittests passed after changes were made
