### PR TITLE
refactor(config): remove config_user from persisted user config

### DIFF
--- a/gitree/objects/config.py
+++ b/gitree/objects/config.py
@@ -155,6 +155,7 @@ class Config:
         del config["version"]
         del config["init_config"]
         del config["no_config"]
+        del config["config_user"]
 
 
         try:


### PR DESCRIPTION
### Summary

`config_user` is a CLI/action flag used to open the user config in an editor and is not a persistent configuration option.  
This PR removes `config_user` from the generated `config.json` file.

### Changes

- Exclude `config_user` from the default user config written to disk
- Preserve existing CLI behavior (`--config-user` still works)

### Additionally, at the time of submission of this PR:

- [x] Ran `gitree --init-config` and verified `config_user` is not written to `config.json`
- [x] Confirmed `gitree --config-user` still opens the config in the editor
- [x] The referred issue is not blocked currently
- [x]  All unittests passed after changes were made
