### PR TITLE
Add class and method docstrings to unittest classes

### DIFF
--- a/tests/base_setup.py
+++ b/tests/base_setup.py
@@ -64,7 +64,7 @@ class BaseCLISetup(unittest.TestCase):
         """
 
         return f"Failed run '{self.base_call} {args_str}'. "
-    
+
 
     def non_zero_exitcode_msg(self, exitcode: int) -> str:
         """
@@ -72,12 +72,12 @@ class BaseCLISetup(unittest.TestCase):
         """
 
         return f"Non-zero exit code: '{exitcode}'. "
-    
-    
+
+
     def no_output_msg(self) -> str:
         """
         Generate message for the no-output issue.
         """
 
         return "No output from the tool. "
-    
+

--- a/tests/test_general_options.py
+++ b/tests/test_general_options.py
@@ -11,11 +11,19 @@ from tests.base_setup import BaseCLISetup
 
 
 class TestGeneralOptions(BaseCLISetup):
+    """
+    Tests general CLI behavior & options, including:
+        - Running gitree with no arguments
+        - Displaying version information (--version)
+        - Enabling verbose logging (--verbose)
+        - Initializing the user config file (--init-config)
+    """
 
     def test_no_arg(self):
         """
-        Test if it is working without any CLI arguments. It should print
-        a tree structure (root name in this case), which includes the name "tmp"
+        Test if it is working without any CLI arguments.
+        It should print a tree structure (root name in this case),
+        which includes the name "tmp"
         """
 
         # Vars
@@ -25,18 +33,20 @@ class TestGeneralOptions(BaseCLISetup):
         result = self.run_gitree(args_str)
 
         # Validate
-        self.assertEqual(0, result.returncode, 
+        self.assertEqual(0, result.returncode,
             msg="Failed default run. " +
                 f"Non-zero exit code: {result.returncode}")
-        
+
         self.assertIn("tmp", result.stdout,
             msg=self.failed_run_msg(args_str) +
                 f"'tmp' not found in output: \n\n{result.stdout}")
-        
+
 
     def test_version(self):
         """
-        Test if it prints the version. Should work for developer version too.
+        Test if it prints the version.
+        Should work for developer version too.
+        using: --version
         """
 
         # Vars
@@ -49,11 +59,11 @@ class TestGeneralOptions(BaseCLISetup):
         self.assertEqual(result.returncode, 0,
             msg=self.failed_run_msg(args_str) +
                 self.non_zero_exitcode_msg(result.returncode))
-        
+
         self.assertTrue(result.stdout.strip(),
             msg=self.failed_run_msg(args_str) +
                 self.no_output_msg())
-        
+
         self.assertIn(".", result.stdout,
             msg=self.failed_run_msg(args_str) +
                 f"No dots found in the output: \n\n{result.stdout}")
@@ -61,7 +71,8 @@ class TestGeneralOptions(BaseCLISetup):
 
     def test_verbose(self):
         """
-        Test if the logging utility is working properly, using --verbose.
+        Test if the logging utility is working properly
+        using: --verbose.
         """
 
         # Vars
@@ -72,15 +83,15 @@ class TestGeneralOptions(BaseCLISetup):
 
         # Validate
         self.assertEqual(result.returncode, 0,
-            msg=self.failed_run_msg(args_str) + 
+            msg=self.failed_run_msg(args_str) +
             self.non_zero_exitcode_msg(result.returncode))
-        
+
         self.assertTrue(result.stdout.strip(),
             msg=self.failed_run_msg(args_str) +
                 self.no_output_msg())
-        
+
         self.assertIn("LOG", result.stdout,
-            msg=self.failed_run_msg(args_str) + 
+            msg=self.failed_run_msg(args_str) +
                 f"Expected str 'LOG' not found in output: \n\n{result.stdout}")
 
 
@@ -97,10 +108,10 @@ class TestGeneralOptions(BaseCLISetup):
         result = self.run_gitree(args_str)
 
         # Validate
-        self.assertEqual(result.returncode, 0, 
+        self.assertEqual(result.returncode, 0,
             msg=self.failed_run_msg(args_str) +
             self.non_zero_exitcode_msg(result.returncode))
-        
-        self.assertTrue(config_path.exists(), 
+
+        self.assertTrue(config_path.exists(),
             msg=self.failed_run_msg(args_str) +
             "config.json was not created")

--- a/tests/test_io_options.py
+++ b/tests/test_io_options.py
@@ -5,10 +5,20 @@ from tests.base_setup import BaseCLISetup
 
 
 class TestIOFlags(BaseCLISetup):
+    """
+    Tests I/O-related CLI flags, including:
+        - Creating zip archives using --zip
+        - Exporting tree output to a file using --export
+    """
+
     # Note: There is no test for copy-to-clipboard currently
     # because real clipboard access is often unavailable/flaky in CI environments.
 
-    def test_zip(self):    
+    def test_zip(self):
+        """
+        Verify that the --zip flag creates a zip archive containing
+        the expected project files.
+        """
         file_path = self.root / "file.txt"
         file_path.write_text("hello", encoding="utf-8")
 
@@ -25,6 +35,10 @@ class TestIOFlags(BaseCLISetup):
 
 
     def test_export(self):
+        """
+        Verify that the --export flag writes the directory tree output
+        to a file and includes file contents.
+        """
         out_path = self.root / "tree_export.txt"
 
         result = self.run_gitree("--export", out_path.name)
@@ -34,4 +48,4 @@ class TestIOFlags(BaseCLISetup):
 
         content = out_path.read_text()
         self.assertIn("CONTENTS", content)
-        
+

--- a/tests/test_listing_options.py
+++ b/tests/test_listing_options.py
@@ -4,13 +4,35 @@ from tests.base_setup import BaseCLISetup
 
 
 class TestListingFlags(BaseCLISetup):
+    """
+    Tests directory listing CLI flags, including:
+        - Displaying file and folder emojis (--emoji)
+        - Limiting tree depth (--max-depth)
+        - Showing hidden files & folders (--hidden-items)
+        - Ordering files before folders (--files-first)
+        - Inclusion overrides that bypass .gitignore (--include)
+    """
 
     @staticmethod
     def __build_name_with_emoji(file_name: str, emoji: str):
+        """
+        Helper to prefix a file or folder name with an emoji.
+
+        Args:
+            file_name (str): Name fo the file or folder
+            emoji (str): Emoji string to append
+
+        Returns:
+            str: Emoji-prefixed name
+        """
         return emoji + " " + file_name
 
 
     def test_emoji(self):
+        """
+        Verify that the --emoji flag correctly prefixes files and folders
+        with the appropriate emojis, including empty and normal directories.
+        """
         file_path = self.root / "file.txt"
         file_path.write_text("hello", encoding="utf-8")
         # Create empty and simple directories to test both emojis
@@ -24,6 +46,10 @@ class TestListingFlags(BaseCLISetup):
 
 
     def test_max_depth(self):
+        """
+        Verity that the --max-depth flag limits the depth of the
+        displayed directory tree.
+        """
         result = self.run_gitree("--max-depth", "1")
 
         self.assertEqual(result.returncode, 0, msg=result.stderr)
@@ -31,6 +57,10 @@ class TestListingFlags(BaseCLISetup):
 
 
     def test_hidden_items(self):
+        """
+        Verify that hidden files and directories are shown only when
+        the --hidden-items flag is used.
+        """
         # Create hidden files and directories
         (self.root / ".hidden_file.txt").write_text("hidden")
         (self.root / ".hidden_dir").mkdir()
@@ -55,6 +85,10 @@ class TestListingFlags(BaseCLISetup):
 
 
     def test_files_first(self):
+        """
+        Verify that the --files-first flag causes files to be listed
+        before folders in the directory tree output.
+        """
         # Create a folder and a file
         tmp_dir = "random_dir"
         tmp_file = "random_file.txt"
@@ -77,6 +111,10 @@ class TestListingFlags(BaseCLISetup):
 
 
     def test_include_overrides_gitignore(self):
+        """
+        Verify that the --include flag can override .gitignore rules,
+        ensuing ignored files are still included if explicitly specified.
+        """
         # Create .gitignore that ignores .py files
         (self.root / ".gitignore").write_text("*.py\n*.log\n")
         (self.root / "script.py").write_text("python")

--- a/tests/test_listing_override_options.py
+++ b/tests/test_listing_override_options.py
@@ -4,11 +4,17 @@ from tests.base_setup import BaseCLISetup
 
 class TestListingControlFlags(BaseCLISetup):
     """
-    Test class for listing control flags (--no-* flags).
-    These flags control what gets displayed in the tree output.
+    Tests listing control flags (--no-* flags) that modify tree output.
+    Includes:
+        - --no-files: hide files from the output
+        - --no-color: disables ANSI color codes in output
     """
 
     def test_no_files(self):
+        """
+        Verify that the --no-files flag correctly hides files from
+        the directory tree output.
+        """
         result = self.run_gitree("--no-files")
 
         self.assertEqual(result.returncode, 0, msg=result.stderr)
@@ -17,6 +23,10 @@ class TestListingControlFlags(BaseCLISetup):
 
 
     def test_no_color(self):
+        """
+        Verify that the --no-color flag disables ANSI color codes
+        in the directory tree output while default output still includes color.
+        """
         # Create additional structure
         (self.root / ".hidden_file").write_text("hidden")
 


### PR DESCRIPTION
### Summary

This PR completes issue #147 by adding clear, descriptive docstrings
to all unittest classes and their test methods across the `tests/` directory.
Additionally, trailing spaces and lines containing only whitespaces were removed for improved
readability and consistency.

### Changes

- Added class-level docstrings to all unittest classes:
  - `TestGeneralOptions`
  - `TestIOFlags`
  - `TestListingFlags`
  - `TestListingControlFlags`
- Added method-level docstrings for each test method in the above classes
- Cleaned up trailing spaces & lines containing **only whitespaces** in all test files

### Additionally, at the time of submission of this PR.
- [x] The referred issue is not blocked currently
- [x] All unittests passed after changes were made