### PR TITLE
Added "no-color = True" if "export" arg is present in _correct_args i…

### DIFF
--- a/gitree/services/parsing_service.py
+++ b/gitree/services/parsing_service.py
@@ -58,8 +58,9 @@ class ParsingService:
         # Prepare the config object to return from this function
         config = Config(ctx, args)
         config.no_printing = config.copy or config.export or config.zip 
-        config.no_color = config.copy or config.export or config.zip
-        
+        if not config.no_color:
+            config.no_color = config.copy or config.export
+
         return ParsingService._fix_contradicting_args(ctx, config)
     
 


### PR DESCRIPTION
…n parsing_service.py

Fixes #266

Additionally, at the time of submission of this PR:

- The referred issue is not blocked currently
- All unittests passed after changes were made
