### PR TITLE
refactor: update main to use DrawingService.run

### DIFF
--- a/gitree/main.py
+++ b/gitree/main.py
@@ -89,7 +89,7 @@ def main() -> None:
             f"Left ZippingService at: {round((time.time()-start_time)*1000, 2)} ms")
 
     else:
-        DrawingService.draw(ctx, config, resolved_root)
+        DrawingService.run(ctx, config, resolved_root)
         ctx.logger.log(Logger.INFO, 
             f"Left DrawingService at: {round((time.time()-start_time)*1000, 2)} ms")
         


### PR DESCRIPTION
Fixes 272

Summary
- Updated `main.py` to call `DrawingService.run()` instead of `draw()`

Reason
This aligns the main workflow with the updated `DrawingService` API.

Notes
- No behavioral changes
- Change is limited to method invocation only
