### PR TITLE
Add --log alias for verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The following optional arguments are available for use:
 | `--version`, `-v` | Display the **version number** of the tool.                                                                       |
 | `--config-user`   | Create a **default config.json** file in the current directory and open that file in the **default editor**.        |
 | `--no-config`     | Ignore both **user-level and global-level** `config.json` and use **default and CLI values** for configuration.       |
-| `--verbose`       | Enable **logger output** to the console. Enabling this prints a log after the full workflow run. Helpful for **debugging**. |
+| `--verbose`, `--log` | Enable **logger output** to the console. Enabling this prints a log after the full workflow run. Helpful for **debugging**. |
 
 ### Output & Export Options
 

--- a/gitree/services/parsing_service.py
+++ b/gitree/services/parsing_service.py
@@ -198,7 +198,7 @@ class ParsingService:
             help="Ignore both user-level and global-level config.json and use"
                 " default and cli values for configuration")
         
-        general.add_argument("--verbose", action="store_true", 
+        general.add_argument("--verbose", "--log", action="store_true", 
             default=argparse.SUPPRESS, 
             help="Enable logger output to the console. Enabling this prints a log"
             " after the full workflow run. Helpful for debugging.")

--- a/tests/test_general_options.py
+++ b/tests/test_general_options.py
@@ -92,3 +92,24 @@ class TestGeneralOptions(BaseCLISetup):
         self.assertIn("LOG", result.stdout,
             msg=self.failed_run_msg(args_str) +
                 f"Expected str 'LOG' not found in output: \n\n{result.stdout}")
+
+    def test_log_alias(self):
+        """
+        Test that --log works as an alias for --verbose.
+        """
+
+        args_str = "--log"
+
+        result = self.run_gitree(args_str)
+
+        self.assertEqual(result.returncode, 0,
+            msg=self.failed_run_msg(args_str) +
+            self.non_zero_exitcode_msg(result.returncode))
+
+        self.assertTrue(result.stdout.strip(),
+            msg=self.failed_run_msg(args_str) +
+                self.no_output_msg())
+
+        self.assertIn("LOG", result.stdout,
+            msg=self.failed_run_msg(args_str) +
+                f"Expected str 'LOG' not found in output: \n\n{result.stdout}")


### PR DESCRIPTION
## Summary
- add `--log` as an alias for `--verbose` to enable logger output
- document the alias in README
- add a regression test to ensure `--log` prints the verbose log

## Rationale
- Issue #302 requests a `--log` alias to mirror the existing verbose flag and keep CLI consistent

## Changes
- extend the argparse option definition to accept both `--verbose` and `--log`
- README option table mentions the new alias
- tests cover `--log` behavior alongside `--verbose`

## Tests
- Passed fork CI (including the new test)