### PR TITLE
Add newline spacing to flush_buffers function

### DIFF
--- a/gitree/main.py
+++ b/gitree/main.py
@@ -26,9 +26,10 @@ from .services.interactive_selection_service import InteractiveSelectionService
 
 
 def flush_buffers(ctx: AppContext, config: Config):
-    """ 
-    Handle flushing the buffers. 
     """
+    Handle flushing the buffers.
+    """
+    print()
 
     # print the export only if not in no_printing and buffer not empty
     if not config.no_printing and not ctx.output_buffer.empty():
@@ -36,10 +37,12 @@ def flush_buffers(ctx: AppContext, config: Config):
 
     # print the log if verbose mode
     if config.verbose:
-        if not config.no_printing and not ctx.output_buffer.empty(): 
+        if not config.no_printing and not ctx.output_buffer.empty():
             print()
         print("LOG:")
         ctx.logger.flush()
+
+    print()
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

Added empty `print()` statements at the start and end of the `flush_buffers` function to make the CLI output cleaner and better spaced.

## Changes

- Added `print()` at the beginning of `flush_buffers` function
- Added `print()` at the end of `flush_buffers` function

## Why

This makes the output from the tool look cleaner and more readable with proper spacing between sections.

Fixes #300

🤖 Generated with [Claude Code](https://claude.ai/code)