### PR TITLE
Add -f alias for --format option

### DIFF
--- a/gitree/services/parsing/parsing_service.py
+++ b/gitree/services/parsing/parsing_service.py
@@ -229,7 +229,7 @@ class ParsingService:
     def _add_listing_flags(ctx: AppContext, ap: argparse.ArgumentParser):
         listing = ap.add_argument_group("listing options")
 
-        listing.add_argument("--format", choices=["tree", "json", "md"], 
+        listing.add_argument("-f","--format", choices=["tree", "json", "md"], 
             default="tree", help="Format output only")
 
         listing.add_argument("--max-items", type=max_items_int, 

--- a/gitree/services/parsing/rich_help_formatter.py
+++ b/gitree/services/parsing/rich_help_formatter.py
@@ -238,7 +238,7 @@ class RichHelpFormatter(argparse.HelpFormatter):
         table.add_column("Description", style="white")
         
         table.add_row(
-            "--format [tree|json|md]",
+            "-f,--format [tree|json|md]",
             "Format output (default: tree)"
         )
         table.add_row(


### PR DESCRIPTION
Adds `-f` as a short alias for the existing `--format` CLI option.
Updates help output to reflect the alias.
No other behavior changed.

Closes #324
