### PR TITLE
Add -x as alias for --export flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ gt -fx project --format md
 | Argument          | Description                                                                                  |
 | ----------------- | -------------------------------------------------------------------------------------------- |
 | `-z`, `--zip`     | Create a **zip archive** of the given directory (respects gitignore if `-g` is used).              |
-| `--export`        | Save **project structure** along with its **contents** to a file with the format specified using `--format`. |
+| `-x`, `--export`        | Save **project structure** along with its **contents** to a file with the format specified using `--format`. |
 | `--format`        | **Format output** only. Options: `tree`, `json`, `md`. Default: `tree`.                      |
 
 <details>

--- a/gitree/services/parsing/parsing_service.py
+++ b/gitree/services/parsing/parsing_service.py
@@ -226,7 +226,7 @@ class ParsingService:
             default=argparse.SUPPRESS, 
             help="Create a zip archive of the given directory (respects gitignore if -g is used).")
         
-        io.add_argument("--export", 
+        io.add_argument("-x", "--export", 
             default=argparse.SUPPRESS, 
             help="Save project structure along with it's contents to a file"
                 " with the format specified using --format")

--- a/gitree/services/parsing/rich_help_formatter.py
+++ b/gitree/services/parsing/rich_help_formatter.py
@@ -208,7 +208,7 @@ class RichHelpFormatter(argparse.HelpFormatter):
             "Create a zip archive of the given directory\n(respects gitignore if -g is used)"
         )
         table.add_row(
-            "--export [FILE]",
+            "-x, --export [FILE]",
             "Save project structure along with its contents to a file\nwith the format specified using --format"
         )
         table.add_row(


### PR DESCRIPTION
Fixes #313 

## Changes Made
- Added `-x` short option to `--export` argument in `parsing_service.py`
- Updated help text in `rich_help_formatter.py` to display `-x, --export [FILE]`
- Updated README to mention the alias

**Additionally, at the time of submission of this PR:**
- The referred issue is not blocked currently
- All unittests passed after changes were made
