### PR TITLE
Color .zip files red in tree output

### DIFF
--- a/gitree/services/drawing_service.py
+++ b/gitree/services/drawing_service.py
@@ -116,6 +116,8 @@ class DrawingService:
                 color = Color.grey
             elif _is_dir(node):
                 color = Color.cyan
+            elif p.lower().endswith(".zip"):
+                color = Color.red
             else:
                 color = Color.default
 


### PR DESCRIPTION
I updated the DrawingService to display .zip files in red color, matching the standard 'ls' command behavior. This was a minimal change to improve file type recognition.